### PR TITLE
Convert shared link from ggdrive and dropbox to downloadable link

### DIFF
--- a/gui/src/js/player_html5.js
+++ b/gui/src/js/player_html5.js
@@ -5,7 +5,7 @@ class Html5Player {
     this.html5_player = sb_player.player;
     this.sb_player = sb_player;
 
-    this.html5_player.src = source;
+    this.html5_player.src = TryGetDownloadableURL(source);
 
     this.WaitUntilVideoIsReady().then(() => { this.sb_player.OnPlayerReady(); } );
 
@@ -106,3 +106,24 @@ class Html5Player {
     return this.html5_player.volume;
   }
 }
+
+function TryGetDownloadableURL(url) {
+  // https://drive.google.com/file/d/1v6tvFKvevjBJ4PIGSH-xScFmiVgV7zct/view?usp=sharing
+  // should become
+  // https://drive.google.com/u/0/uc?id=1v6tvFKvevjBJ4PIGSH-xScFmiVgV7zct&export=download
+  let match = url.match(/^https:\/\/drive.google.com\/file\/d\/([-\w]{25,})/);
+  if (match) {
+    return 'https://drive.google.com/u/0/uc?id=' + match[1] + '&export=download';
+  }
+
+  // https://www.dropbox.com/s/h6gmkr17ds9mcq4/file_example_MP4_480_1_5MG.mp4?dl=0
+  // should become
+  // https://www.dropbox.com/s/h6gmkr17ds9mcq4/file_example_MP4_480_1_5MG.mp4?dl=1
+  match = url.match(/(^https:\/\/www.dropbox.com\/s\/[\w]+\/[%\.\w]+)(\?dl=0)?/);
+  if (match) {
+    return match[1] + '?dl=1';
+  }
+
+  return url;
+}
+


### PR DESCRIPTION
Allow users to upload their videos to google drive or dropbox and paste the shared link directly in the URL input box (not sure it will work for all links, though)